### PR TITLE
Correct typo

### DIFF
--- a/words
+++ b/words
@@ -297,7 +297,7 @@ else
     words.note "palpable"          , "able to be touched or felt, (esp. of a feeling or atmosphere) so intense as to be almost touched or felt: a palpable sense of loss."
     words.note "perennial"         , "lasting or existing for a long or apparently infinite time; enduring or continually recurring; apparently permanently engaged in a specified role or way of life"
     words.note "perfidy"           , "deceitfulness; untrustworthiness."
-    words.note "performativity"    , "(my defn) speach which determines the identity of a person -- ie the language defines who the person is, rather than who they are dictating their language"
+    words.note "performativity"    , "(my defn) speech which determines the identity of a person -- ie the language defines who the person is, rather than who they are dictating their language"
     words.note "petulant"          , "childishly sulky or bad-tempered"
     words.note "platitude"         , "a remark or statement, esp. one with a moral content, that has been used too often to be interesting or thoughtful" , "aphorism", "adage", "maxim", "proverb", "platitude", "fable", "epigram"
     words.note "polymathy"         , "a person of wide-ranging knowledge or learning."


### PR DESCRIPTION
My "scanning" of this list picked up this typo. 😉 